### PR TITLE
setting ST_Point class to public so the UDF is visible

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/hive/ST_Point.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/ST_Point.java
@@ -32,7 +32,7 @@ import com.esri.core.geometry.ogc.OGCGeometry;
 //		}
 //	)
 
-class ST_Point extends ST_Geometry {
+public class ST_Point extends ST_Geometry {
 	static final Log LOG = LogFactory.getLog(ST_Point.class.getName());
 
 	// Number-pair constructor - 2D


### PR DESCRIPTION
This one UDF was not set public so in Hive 12, using "ST_Point(<longitude>, <latitude>)" was failing.
