### PR TITLE
Bug fix: Convert column names to lower case

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/hive/serde/JsonSerde.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/serde/JsonSerde.java
@@ -84,7 +84,7 @@ public class JsonSerde implements SerDe {
 				.getTypeInfosFromTypeString(columnTypeProperty);
 
 		columnNames = new ArrayList<String>();
-		columnNames.addAll(Arrays.asList(columnNameProperty.split(",")));
+		columnNames.addAll(Arrays.asList(columnNameProperty.toLowerCase().split(",")));
 
 		numColumns = columnNames.size();
 		


### PR DESCRIPTION
Otherwise, it can't find the name if it's not lower case.
