### PR TITLE
Fix wrong String comparison in EnclosedJsonRecordReader

### DIFF
--- a/json/src/main/java/com/esri/json/hadoop/EnclosedJsonRecordReader.java
+++ b/json/src/main/java/com/esri/json/hadoop/EnclosedJsonRecordReader.java
@@ -77,7 +77,7 @@ public class EnclosedJsonRecordReader implements RecordReader<LongWritable, Text
 			
 			token = parser.nextToken();
 			
-			while (token != null && !(token == JsonToken.START_ARRAY && parser.getCurrentName() == "features")){
+			while (token != null && !(token == JsonToken.START_ARRAY && parser.getCurrentName().equals("features"))) {
 				token = parser.nextToken();
 			}
 			

--- a/json/src/main/java/com/esri/json/hadoop/EnclosedJsonRecordReader.java
+++ b/json/src/main/java/com/esri/json/hadoop/EnclosedJsonRecordReader.java
@@ -77,7 +77,8 @@ public class EnclosedJsonRecordReader implements RecordReader<LongWritable, Text
 			
 			token = parser.nextToken();
 			
-			while (token != null && !(token == JsonToken.START_ARRAY && parser.getCurrentName().equals("features"))) {
+			while (token != null && !(token == JsonToken.START_ARRAY &&
+					parser.getCurrentName() != null && parser.getCurrentName().equals("features"))) {
 				token = parser.nextToken();
 			}
 			


### PR DESCRIPTION
`parser.getCurrentName()` should be compared using `String#equals`.