### PR TITLE
Added a simple ST_AsShape UDF returning the Esri shape representation.

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/hive/ST_AsShape.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/ST_AsShape.java
@@ -1,0 +1,44 @@
+package com.esri.hadoop.hive;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.io.BytesWritable;
+
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.GeometryEngine;
+import com.esri.core.geometry.ogc.OGCGeometry;
+
+@Description(
+		name = "ST_AsShape",
+		value = "_FUNC_(ST_Geometry) - return Esri shape representation of geometry\n",
+		extended = "Example:\n" +
+		"  SELECT _FUNC_(ST_Point(1, 2)) FROM onerow; -- Esri shape representation of POINT (1 2)\n"
+		)
+public class ST_AsShape extends ST_Geometry {
+
+	static final Log LOG = LogFactory.getLog(ST_AsShape.class.getName());
+	
+	public BytesWritable evaluate(BytesWritable geomref) {
+		if (geomref == null || geomref.getLength() == 0){
+			LogUtils.Log_ArgumentsNull(LOG);
+			return null;
+		}
+
+		OGCGeometry ogcGeometry = GeometryUtils.geometryFromEsriShape(geomref);
+		if (ogcGeometry == null){
+			LogUtils.Log_ArgumentsNull(LOG);
+			return null;
+		}
+
+		try {
+			// Get Esri shape representation
+			Geometry esriGeometry = ogcGeometry.getEsriGeometry();
+			byte[] esriShape = GeometryEngine.geometryToEsriShape(esriGeometry);
+			return new BytesWritable(esriShape);
+		} catch (Exception e){
+			LOG.error(e.getMessage());
+			return null;
+		}
+	}
+}

--- a/hive/src/test/java/com/esri/hadoop/hive/TestStAsShape.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/TestStAsShape.java
@@ -1,0 +1,39 @@
+package com.esri.hadoop.hive;
+
+import static org.junit.Assert.*;
+
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.junit.Test;
+
+import com.esri.core.geometry.GeometryEngine;
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.Geometry;
+import com.esri.core.geometry.Geometry.Type;
+
+public class TestStAsShape {
+
+	private final static double Epsilon = 0.0001;
+	
+	@Test
+	public void testPointAsShape() {
+		ST_Point point = new ST_Point();
+		final double longitude = 12.224;
+		final double latitude = 51.829;
+		BytesWritable pointAsWritable = point.evaluate(new DoubleWritable(longitude), new DoubleWritable(latitude));
+		assertNotNull("The point writable must not be null!", pointAsWritable);
+		
+		ST_AsShape asShape = new ST_AsShape();
+		BytesWritable shapeAsWritable = asShape.evaluate(pointAsWritable);
+		assertNotNull("The shape writable must not be null!", pointAsWritable);
+		
+		byte[] esriShapeBuffer = shapeAsWritable.getBytes();
+		Geometry esriGeometry = GeometryEngine.geometryFromEsriShape(esriShapeBuffer, Type.Point);
+		assertNotNull("The geometry must not be null!", esriGeometry);
+		assertTrue("Geometry type point expected!", esriGeometry instanceof Point);
+		
+		Point esriPoint = (Point) esriGeometry;
+		assertEquals("Longitude is different!", longitude, esriPoint.getX(), Epsilon);
+		assertEquals("Latitude is different!", latitude, esriPoint.getY(), Epsilon);
+	}
+}


### PR DESCRIPTION
There was a need for that. The Esri shape representation can be used for exporting the geometries into other data stores like HBase.