### PR TITLE
BaseJsonSerDe: DATE & TIMESTAMP types

### DIFF
--- a/hive/src/test/java/com/esri/hadoop/hive/serde/JsonSerDeTestingBase.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/serde/JsonSerDeTestingBase.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.io.BooleanWritable;
@@ -48,6 +50,14 @@ public abstract class JsonSerDeTestingBase {
 
 	protected void addWritable(ArrayList<Object> stuff, String item) {
 		stuff.add(new Text(item));
+	}
+
+	protected void addWritable(ArrayList<Object> stuff, java.sql.Date item) {
+		stuff.add(new DateWritable(item));
+	}
+
+	protected void addWritable(ArrayList<Object> stuff, java.sql.Timestamp item) {
+		stuff.add(new TimestampWritable(item));
 	}
 
 	protected void addWritable(ArrayList<Object> stuff, Geometry geom) {

--- a/pom.xml
+++ b/pom.xml
@@ -108,13 +108,25 @@
     <profile>
       <id>hadoop-2.6</id>
       <properties>
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>2.6.5</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.2</hadoop.version>
+        <hadoop.version>2.7.3</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-2.8</id>
+      <properties>
+        <hadoop.version>2.8.0</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-3.0</id>
+      <properties>
+        <hadoop.version>3.0.0-alpha2</hadoop.version>
       </properties>
     </profile>
 
@@ -186,7 +198,7 @@
     <profile>
       <id>hive-1.2</id>
       <properties>
-        <hive.version>1.2.1</hive.version>
+        <hive.version>1.2.2</hive.version>
       </properties>
     </profile>
     <profile>
@@ -198,7 +210,7 @@
     <profile>
       <id>hive-2.1</id>
       <properties>
-        <hive.version>2.1.0</hive.version>
+        <hive.version>2.1.1</hive.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
#101 @SrinivasRIL
Requires Hive-0.12+ dependencies to build, but should execute OK on 0.11 and 0.10 versions.  Alternate would be shims, or support `timestamp` only and not `date` which was introduced in v0.12 of Hive.