### PR TITLE
AbstractSerDe class rather than obsolete SerDe interface

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/hive/serde/BaseJsonSerDe.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/serde/BaseJsonSerDe.java
@@ -11,7 +11,7 @@ import java.util.TimeZone;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
@@ -48,7 +48,7 @@ import com.esri.hadoop.hive.GeometryUtils;
 import com.esri.hadoop.shims.HiveShims;
 
 
-abstract public class BaseJsonSerDe implements SerDe {
+abstract public class BaseJsonSerDe extends AbstractSerDe {
 	static final Log LOG = LogFactory.getLog(BaseJsonSerDe.class.getName());
 
 	static protected JsonFactory jsonFactory = new JsonFactory();

--- a/hive/src/test/java/com/esri/hadoop/hive/serde/JsonSerDeTestingBase.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/serde/JsonSerDeTestingBase.java
@@ -3,7 +3,7 @@ package com.esri.hadoop.hive.serde;
 import org.junit.Assert;
 import java.util.ArrayList;
 
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
@@ -82,7 +82,7 @@ public abstract class JsonSerDeTestingBase {
 		return rowOI.getStructFieldData(row, f0);
 	}
 
-	protected Object runSerDe(Object stuff, SerDe jserde, StructObjectInspector rowOI) throws Exception {
+	protected Object runSerDe(Object stuff, AbstractSerDe jserde, StructObjectInspector rowOI) throws Exception {
 		Writable jsw = jserde.serialize(stuff, rowOI);
 		//System.err.println(jsw);
 		return jserde.deserialize(jsw);

--- a/hive/src/test/java/com/esri/hadoop/hive/serde/TestEsriJsonSerDe.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/serde/TestEsriJsonSerDe.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
@@ -47,7 +47,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"attributes":{"num":7}}
@@ -65,7 +65,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"attributes":{"when":147147147147}}
@@ -87,7 +87,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "timestamp");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"attributes":{"when":147147147147}}
@@ -108,7 +108,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"attributes":{},"geometry":{"x":15.0,"y":5.0}}
@@ -126,7 +126,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
@@ -151,7 +151,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
@@ -176,7 +176,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
@@ -203,7 +203,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "timestamp");
@@ -242,7 +242,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
@@ -268,7 +268,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         addWritable(stuff, 7);
@@ -289,7 +289,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"attributes\":{},\"geometry\":{\"x\":15.0,\"y\":5.0}}");
@@ -312,7 +312,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num,shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "bigint,binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"attributes\":{\"num\":7},\"geometry\":{\"x\":15.0,\"y\":5.0}}");
@@ -339,7 +339,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"attributes\":{\"num\":7}}");
@@ -360,7 +360,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"attributes\":{},\"geometry\":{\"x\":15.0,\"y\":5.0}}");
@@ -382,7 +382,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "flag,num1,num2,text");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "boolean,tinyint,smallint,string");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
 		// {"attributes":{"flag":false,"num":"5","text":"Point(15.0 5.0)"}}
@@ -430,7 +430,7 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num,shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "bigint,binary");
 		Configuration config = new Configuration();
-		SerDe jserde = new JsonSerde();
+		AbstractSerDe jserde = new JsonSerde();
 		jserde.initialize(config, proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
@@ -453,9 +453,9 @@ public class TestEsriJsonSerDe extends JsonSerDeTestingBase {
 	}
     * */
 
-	private SerDe mkSerDe(Properties proptab) throws Exception {
+	private AbstractSerDe mkSerDe(Properties proptab) throws Exception {
 		Configuration config = new Configuration();
-		SerDe jserde = new EsriJsonSerDe();
+		AbstractSerDe jserde = new EsriJsonSerDe();
 		jserde.initialize(config, proptab);
 		return jserde;
 	}

--- a/hive/src/test/java/com/esri/hadoop/hive/serde/TestGeoJsonSerDe.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/serde/TestGeoJsonSerDe.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.TimeZone;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
@@ -40,7 +40,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"properties":{"num":7}}
@@ -58,7 +58,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"properties":{"when":147147147147}}
@@ -80,7 +80,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // {"properties":{},"geometry":{"type":"Point","coordinates":[15.0,5.0]}}
@@ -98,7 +98,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new GeoJsonSerDe();
+		AbstractSerDe jserde = new GeoJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
@@ -122,7 +122,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new GeoJsonSerDe();
+		AbstractSerDe jserde = new GeoJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
@@ -147,7 +147,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new GeoJsonSerDe();
+		AbstractSerDe jserde = new GeoJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
@@ -174,7 +174,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Configuration config = new Configuration();
 		Text value = new Text();
 
-		SerDe jserde = new GeoJsonSerDe();
+		AbstractSerDe jserde = new GeoJsonSerDe();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
@@ -200,7 +200,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"properties\":{\"num\":7}}");
@@ -221,7 +221,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[15.0,5.0]}}");
@@ -244,7 +244,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num,shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "bigint,binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         // value.set("{\"properties\":{\"num\":7},\"geometry\":{\"type\":\"Point\",\"coordinates\":[15.0,5.0]}}");
@@ -271,7 +271,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "num");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "int");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"properties\":{\"num\":7}}");
@@ -292,7 +292,7 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "shape");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "binary");
-		SerDe jserde = mkSerDe(proptab);
+		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
 
         //value.set("{\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[15.0,5.0]}}");
@@ -309,9 +309,9 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 	}
 
 
-	private SerDe mkSerDe(Properties proptab) throws Exception {
+	private AbstractSerDe mkSerDe(Properties proptab) throws Exception {
 		Configuration config = new Configuration();
-		SerDe jserde = new GeoJsonSerDe();
+		AbstractSerDe jserde = new GeoJsonSerDe();
 		jserde.initialize(config, proptab);
 		return jserde;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,27 @@
 		</license>
   </licenses>
 
+  <developers>
+    <developer>
+      <id>climbage</id>
+      <name>Michael Park</name>
+      <organization>Esri</organization>
+      <organizationUrl>http://www.esri.com</organizationUrl>
+      <roles>
+	<role>developer</role>
+      </roles>
+    </developer>
+    <developer>
+      <id>randallwhitman</id>
+      <name>Randall Whitman</name>
+      <organization>Esri</organization>
+      <organizationUrl>http://www.esri.com</organizationUrl>
+      <roles>
+	<role>developer</role>
+      </roles>
+    </developer>
+  </developers>
+
 	<parent>
   	<groupId>org.sonatype.oss</groupId>
   	<artifactId>oss-parent</artifactId>
@@ -114,7 +135,7 @@
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.3</hadoop.version>
+        <hadoop.version>2.7.4</hadoop.version>
       </properties>
     </profile>
     <profile>
@@ -126,7 +147,7 @@
     <profile>
       <id>hadoop-3.0</id>
       <properties>
-        <hadoop.version>3.0.0-alpha4</hadoop.version>
+        <hadoop.version>3.0.0-beta1</hadoop.version>
       </properties>
     </profile>
 
@@ -212,6 +233,45 @@
       <properties>
         <hive.version>2.1.1</hive.version>
       </properties>
+    </profile>
+    <profile>
+      <id>hive-2.2</id>
+      <properties>
+        <hive.version>2.2.0</hive.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>hive-2.3</id>
+      <properties>
+        <hive.version>2.3.0</hive.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+	<plugins>
+	  <plugin>
+	    <groupId>org.apache.maven.plugins</groupId>
+	    <artifactId>maven-gpg-plugin</artifactId>
+	    <executions>
+	      <execution>
+		<id>sign-artifacts</id>
+		<phase>verify</phase>
+		<goals>
+		  <goal>sign</goal>
+		</goals>
+	      </execution>
+	    </executions>
+	  </plugin>
+	</plugins>
+      </build>
     </profile>
 
   </profiles>
@@ -344,6 +404,18 @@
             </execution>
           </executions>
         </plugin>
+	<plugin>
+	  <groupId>org.sonatype.plugins</groupId>
+	  <artifactId>nexus-staging-maven-plugin</artifactId>
+	  <version>1.6.7</version>
+	  <extensions>true</extensions>
+	  <configuration>
+	    <serverId>ossrh</serverId>
+	    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+	    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+	  </configuration>
+	</plugin>
+
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Required as of Hive-v2.3; available as of Hive-0.11, which is more than 5 releases ago.
Spatial Framework will now require Hive-0.11+ to use the JSON SerDe classes; it had already required Hive-0.12+ to build from source.