### PR TITLE
ST_GeomFromJson fails compile checking incorrect Exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ json/javadoc/
 spatial-sdk-hadoop.jar
 hive/spatial-sdk-hive.jar
 json/spatial-sdk-json.jar
+hive/target
+json/target
+.idea
+*.iml

--- a/hive/src/main/java/com/esri/hadoop/hive/ST_GeomFromJson.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/ST_GeomFromJson.java
@@ -48,11 +48,9 @@ public class ST_GeomFromJson extends GenericUDF{
 		try {
 			OGCGeometry ogcGeom = OGCGeometry.fromJson(json);
 			return GeometryUtils.geometryToEsriShapeBytesWritable(ogcGeom);
-		} catch (JsonParseException e) {
-			
-		} catch (IOException e) {
+		} catch (Exception e) {
 
-		} 
+		}
 		
 		return null;
 	}


### PR DESCRIPTION
By pulling and trying to compile the master branch, I was getting these failures:

[ERROR] /.../ST_GeomFromJson.java:[51,4] error: exception JsonParseException is never thrown in body of corresponding try statement
[ERROR] /.../ST_GeomFromJson.java:[53,4] error: exception IOException is never thrown in body of corresponding try statement

Looks like the interface changed for the calls to:

OGCGeometry.fromJson
GeometryUtils.geometryToEsriShapeBytesWritable

That no longer warrant a check for the JsonParseException and IOExceptions. Made it more generic now with the overarching Exception.

Added a few files to the gitignore to keep the branch clean.