### PR TITLE
POM changes for v2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 	<scm>
 		<connection>scm:git:git@github.com:Esri/spatial-framework-for-hadoop.git</connection>
 		<developerConnection>scm:git:git@github.com:Esri/spatial-framework-for-hadoop.git</developerConnection>
-		<url>git@github.com:Esri/spatial-framework-for-hadoop.git</url>
+		<url>https://github.com/Esri/spatial-framework-for-hadoop</url>
 	</scm>
 
   <modules>
@@ -141,7 +141,7 @@
     <profile>
       <id>hadoop-2.8</id>
       <properties>
-        <hadoop.version>2.8.1</hadoop.version>
+        <hadoop.version>2.8.2</hadoop.version>
       </properties>
     </profile>
     <profile>
@@ -151,17 +151,25 @@
       </properties>
     </profile>
 
-    <profile>  <!-- compile error on com.google.common.cache in hive module, with -Phadoop-1.x -->
-      <id>hive-.10</id>
-      <properties>
-        <hive.version>0.10.0</hive.version>
-      </properties>
-    </profile>
     <profile>
-      <id>hive-.11</id>
+      <id>hive-.11</id>  <!-- Need to build with Hive-0.12 before testing with 0.11 -->
       <properties>
         <hive.version>0.11.0</hive.version>
       </properties>
+      <!-- NEEDED with Hive-0.11  dependencies>
+	<dependency>
+	  <groupId>javax.jdo</groupId>
+	  <artifactId>jdo2-api</artifactId>
+	  <version>2.3-ec</version>
+	</dependency>
+      </dependencies>
+      <repositories>
+	<repository>
+	  <id>org.datanucleus</id>
+	  <name>datanucleus</name>
+	  <url>http://www.datanucleus.org/downloads/maven2/</url>
+	</repository>
+      </repositories -->
     </profile>
     <profile>
       <id>hive-.12</id>
@@ -243,7 +251,7 @@
     <profile>
       <id>hive-2.3</id>
       <properties>
-        <hive.version>2.3.0</hive.version>
+        <hive.version>2.3.1</hive.version>
       </properties>
     </profile>
 
@@ -296,22 +304,8 @@
     <javadoc.plugin.version>2.8</javadoc.plugin.version>
   </properties>
 
-	<repositories>
-		<repository>
-			<id>org.datanucleus</id>
-			<name>datanucleus</name>
-			<url>http://www.datanucleus.org/downloads/maven2/</url>
-		</repository>
-	</repositories>
-
   <dependencyManagement>
     <dependencies>
-
-	  	<dependency>
-				<groupId>javax.jdo</groupId>
-				<artifactId>jdo2-api</artifactId>
-				<version>2.3-ec</version>
-	  	</dependency>
 
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Other `<repositories>` [discouraged by The Central Repository](http://central.sonatype.org/pages/requirements.html) - see also #89.  (In the non-default Hive-0.11 profile where datanucleus repo is needed, it is commented out.)
GitHub URL matching the sample in style.
Minor updates to profiles for Hive and Hadoop versions.