### PR TITLE
Jackson dependency version in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
     </profile>
 
     <profile>
+      <id>jackson-2.6</id>
+      <properties>
+        <jackson.version>2.6.7.1</jackson.version>  <!-- Deploy from GitHub -->
+      </properties>
+    </profile>
+
+    <profile>
       <id>hadoop-1.1</id>
       <properties>
         <hadoop.version>1.1.1</hadoop.version>
@@ -146,19 +153,25 @@
     <profile>
       <id>hadoop-2.7</id>
       <properties>
-        <hadoop.version>2.7.4</hadoop.version>
+        <hadoop.version>2.7.5</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-2.8</id>
       <properties>
-        <hadoop.version>2.8.2</hadoop.version>
+        <hadoop.version>2.8.3</hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>hadoop-2.9</id>
+      <properties>
+        <hadoop.version>2.9.0</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-3.0</id>
       <properties>
-        <hadoop.version>3.0.0-beta1</hadoop.version>
+        <hadoop.version>3.0.0</hadoop.version>
       </properties>
     </profile>
 
@@ -262,7 +275,7 @@
     <profile>
       <id>hive-2.3</id>
       <properties>
-        <hive.version>2.3.1</hive.version>
+        <hive.version>2.3.2</hive.version>
       </properties>
     </profile>
 
@@ -304,7 +317,7 @@
     <!-- Versions for dependencies -->
     <hadoop.version>2.2.0</hadoop.version>
     <hive.version>0.12.0</hive.version>
-    <jackson.version>2.6.5</jackson.version>
+    <jackson.version>2.8.11</jackson.version>
     <logging.version>1.1.3</logging.version>
     <geometry.version>2.0.0</geometry.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
The deployed version of Jackson would matter more than the compile-dependency version.  [CVE-2017-7525](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525)

+ updated non-default profiles for Hadoop & Hive versions

(#146)