### PR TITLE
POM: Upgrade to Geometry v2.1 with Jackson v2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,13 @@
     </profile>
 
     <profile>
+      <id>jackson-2.8</id>
+      <properties>
+        <jackson.version>2.8.11</jackson.version>
+      </properties>
+    </profile>
+
+    <profile>
       <id>hadoop-1.1</id>
       <properties>
         <hadoop.version>1.1.1</hadoop.version>
@@ -317,9 +324,9 @@
     <!-- Versions for dependencies -->
     <hadoop.version>2.2.0</hadoop.version>
     <hive.version>0.12.0</hive.version>
-    <jackson.version>2.8.11</jackson.version>
+    <jackson.version>2.9.4</jackson.version>
     <logging.version>1.1.3</logging.version>
-    <geometry.version>2.0.0</geometry.version>
+    <geometry.version>2.1.0</geometry.version>
     <junit.version>4.11</junit.version>
 
     <!-- Versions for plugins -->


### PR DESCRIPTION
Latest released Geometry API and consistent Jackson dependency.