### PR TITLE
POM: Upgrade to Geometry v2.2 and Jackson v2.9.6

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,9 +6,9 @@
 		<dependency groupId="org.apache.hadoop" artifactId="hadoop-client" version="2.2.0"/>
 		<dependency groupId="org.apache.hive" artifactId="hive-exec" version="0.12.0"/>
 		<dependency groupId="org.apache.hive" artifactId="hive-serde" version="0.12.0"/>
-		<dependency groupId="com.esri.geometry" artifactId="esri-geometry-api" version="2.1.99"/>  <!-- 2.2.0-SNAPSHOT -->
-		<dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.6.5"/>
-		<dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.6.5"/>
+		<dependency groupId="com.esri.geometry" artifactId="esri-geometry-api" version="2.2.0"/>
+		<dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-core" version="2.9.6"/>
+		<dependency groupId="com.fasterxml.jackson.core" artifactId="jackson-databind" version="2.9.6"/>
 	</artifact:dependencies>
 	
 	<target name="init">

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <profile>
       <id>hadoop-3.0</id>
       <properties>
-        <hadoop.version>3.0.2</hadoop.version>  <!-- hadoop-project-dist-3.0.3 ? -->
+        <hadoop.version>3.0.2</hadoop.version>  <!-- 3.0.3 ? -->
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -110,14 +110,14 @@
     <profile>
       <id>jackson-2.6</id>
       <properties>
-        <jackson.version>2.6.7.1</jackson.version>  <!-- Deploy from GitHub -->
+        <jackson.version>2.6.7.1</jackson.version>
       </properties>
     </profile>
 
     <profile>
       <id>jackson-2.8</id>
       <properties>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.8.11.2</jackson.version>
       </properties>
     </profile>
 
@@ -172,19 +172,19 @@
     <profile>
       <id>hadoop-2.8</id>
       <properties>
-        <hadoop.version>2.8.3</hadoop.version>
+        <hadoop.version>2.8.4</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-2.9</id>
       <properties>
-        <hadoop.version>2.9.0</hadoop.version>
+        <hadoop.version>2.9.1</hadoop.version>
       </properties>
     </profile>
     <profile>
       <id>hadoop-3.0</id>
       <properties>
-        <hadoop.version>3.0.2</hadoop.version>
+        <hadoop.version>3.0.2</hadoop.version>  <!-- hadoop-project-dist-3.0.3 ? -->
       </properties>
     </profile>
     <profile>
@@ -298,6 +298,12 @@
         <hive.version>2.3.3</hive.version>
       </properties>
     </profile>
+    <profile>
+      <id>hive-3.0</id>
+      <properties>
+        <hive.version>3.0.0</hive.version>
+      </properties>
+    </profile>
 
     <profile>
       <id>release-sign-artifacts</id>
@@ -337,9 +343,9 @@
     <!-- Versions for dependencies -->
     <hadoop.version>2.2.0</hadoop.version>
     <hive.version>0.12.0</hive.version>
-    <jackson.version>2.9.4</jackson.version>
+    <jackson.version>2.9.6</jackson.version>
     <logging.version>1.1.3</logging.version>
-    <geometry.version>2.2.0-SNAPSHOT</geometry.version>
+    <geometry.version>2.2.0</geometry.version>
     <junit.version>4.11</junit.version>
 
     <!-- Versions for plugins -->


### PR DESCRIPTION
Geometry production release including centroid.
Jackson version matching Geometry.