### PR TITLE
ST_Aggr_ConvexHull: fix convex hull of single geometry

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/hive/ST_Aggr_ConvexHull.java
+++ b/hive/src/main/java/com/esri/hadoop/hive/ST_Aggr_ConvexHull.java
@@ -110,8 +110,8 @@ public class ST_Aggr_ConvexHull extends UDAF {
 		 * in the current buffer
 		 */
 		private void maybeAggregateBuffer(boolean force) throws HiveException {
-
-			if (force || geometries.size() > MAX_BUFFER_SIZE){
+			// Skip computing if there is none or single geometry buffered
+			if ((force && geometries.size() > 1) || geometries.size() > MAX_BUFFER_SIZE){
 				Geometry[] geomArray = new Geometry[geometries.size()];
 				geometries.toArray(geomArray);
 				geometries.clear();


### PR DESCRIPTION
The convex hull of a single geometry should be itself. However, the result without this patch returns an empty multi polygon.