### PR TITLE
JSON SerDe: date column in any time zone - for at least Hive-3.1+

### DIFF
--- a/hive/src/main/java/com/esri/hadoop/shims/HiveShims.java
+++ b/hive/src/main/java/com/esri/hadoop/shims/HiveShims.java
@@ -3,7 +3,9 @@ package com.esri.hadoop.shims;
 import java.lang.reflect.Method;
 import java.util.TimeZone;
 
-
+/**
+ * These shims are internal to Spatial-Framework-for-Hadoop and subject to change without notice.
+ */
 public class HiveShims {
 
 	/**
@@ -48,7 +50,7 @@ public class HiveShims {
     /**
      * Classes o.a.h.h.common.type Date & Timestamp were introduced in Hive-3.1 version.
      */
-    public static Long getPrimitiveEpoch(Object prim, TimeZone tz) {
+    public static Long getPrimitiveEpoch(Object prim) {
         if (prim instanceof java.sql.Timestamp) {
 			return ((java.sql.Timestamp)prim).getTime();
         } else if (prim instanceof java.util.Date) {
@@ -78,9 +80,8 @@ public class HiveShims {
 	 * Type DATE was introduced in Hive-0.12 - class DateWritable in API.
      * Class DateWritableV2 is used instead as of Hive-3.1 version.
 	 */
-    public static void setDateWritable(Object dwHive, long epoch
-                                       , TimeZone tz
-                                       ) {
+	// See HIVE-12192.
+    public static void setDateWritable(Object dwHive, long epoch) {
         try {			    	                    // Hive 3.1 and above
             Class<?> dtClazz = Class.forName("org.apache.hadoop.hive.common.type.Date");
             Class<?> dwClazz = Class.forName("org.apache.hadoop.hive.serde2.io.DateWritableV2");
@@ -97,32 +98,7 @@ public class HiveShims {
             } catch (Exception e2) {	            // Hive 0.11 and below
                 // column type DATE not supported
                 throw new UnsupportedOperationException("DATE type");
-                }
-        }
-    }  // setDateWritable
-
-	/**
-	 * Type DATE was introduced in Hive-0.12 - class DateWritable in API.
-     * Class DateWritableV2 is used instead as of Hive-3.1 version.
-	 */
-    public static void setDateWritable(Object dwHive, java.sql.Date jsd) {
-        try {			    	                    // Hive 3.1 and above
-            Class<?> dtClazz = Class.forName("org.apache.hadoop.hive.common.type.Date");
-            Class<?> dwClazz = Class.forName("org.apache.hadoop.hive.serde2.io.DateWritableV2");
-            Method dtSetImpl = dtClazz.getMethod("setTimeInMillis", long.class);
-            Method dwSetImpl = dwClazz.getMethod("set", dtClazz);
-            Object dtObj = dtClazz.getConstructor().newInstance();
-            dtSetImpl.invoke(dtObj, jsd.getTime());
-            dwSetImpl.invoke(dwHive, dtObj);
-        } catch (Exception e1) {
-            try {				                    // Hive 0.12 and above
-                Class<?> dwClazz = Class.forName("org.apache.hadoop.hive.serde2.io.DateWritable");
-                Method dwSetImpl = dwClazz.getMethod("set", java.sql.Date.class);
-                dwSetImpl.invoke(dwHive, jsd);
-            } catch (Exception e2) {	            // Hive 0.11 and below
-                // column type DATE not supported
-                throw new UnsupportedOperationException("DATE type");
-                }
+            }
         }
     }  // setDateWritable
 
@@ -151,29 +127,4 @@ public class HiveShims {
         }
     }  // setTimeWritable
 
-	/**
-	 * Type TIMESTAMP was introduced in Hive-0.12 - class TimestampWritable in API.
-     * Class TimestampWritableV2 is used instead as of Hive-3.1 version.
-	 */
-    public static void setTimeWritable(Object twHive, java.sql.Timestamp jst) {
-        long epoch = jst.getTime();
-        try {			    	                    // Hive 3.1 and above
-            Class<?> ttClazz = Class.forName("org.apache.hadoop.hive.common.type.Timestamp");
-            Class<?> twClazz = Class.forName("org.apache.hadoop.hive.serde2.io.TimestampWritableV2");
-            Method ttSetImpl = ttClazz.getMethod("setTimeInMillis", long.class);
-            Method twSetImpl = twClazz.getMethod("set", ttClazz);
-            Object ttObj = ttClazz.getConstructor().newInstance();
-            ttSetImpl.invoke(ttObj, epoch);
-            twSetImpl.invoke(twHive, ttObj);
-        } catch (Exception e1) {
-            try {				                    // Hive 0.12 and above
-                Class<?> twClazz = Class.forName("org.apache.hadoop.hive.serde2.io.TimestampWritable");
-                Method twSetImpl = twClazz.getMethod("set", java.sql.Timestamp.class);
-                twSetImpl.invoke(twHive, new java.sql.Timestamp(epoch));
-            } catch (Exception e2) {	            // Hive 0.11 and below
-                // column type TIMESTAMP not supported
-                throw new UnsupportedOperationException("TIMESTAMP type");
-            }
-        }
-    }  // setTimeWritable
 }

--- a/hive/src/test/java/com/esri/hadoop/hive/serde/TestGeoJsonSerDe.java
+++ b/hive/src/test/java/com/esri/hadoop/hive/serde/TestGeoJsonSerDe.java
@@ -54,24 +54,33 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 
 	@Test
 	public void TestEpochWrite() throws Exception {
-        ArrayList<Object> stuff = new ArrayList<Object>();
 		Properties proptab = new Properties();
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMNS, "when");
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
 		AbstractSerDe jserde = mkSerDe(proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
+		long day = 24*3600*1000;  // DateWritable represents days not milliseconds.
 
-        // {"properties":{"when":147147147147}}
-		long epoch = 147147147147L;
-        long zoned = epoch - TimeZone.getDefault().getOffset(epoch);
-        java.sql.Date expected = new java.sql.Date(zoned);
-        addWritable(stuff, expected);
+		long epoch = 1641535200000L;  // 2022-01-07 06:00 UTC
+        java.sql.Date jsd = new java.sql.Date(epoch);  // zoned?
+		ArrayList<Object> stuff = new ArrayList<Object>();
+        addWritable(stuff, jsd);
         Writable jsw = jserde.serialize(stuff, rowOI);
 		JsonNode jn = new ObjectMapper().readTree(((Text)jsw).toString());
 		jn = jn.findValue("properties");
 		jn = jn.findValue("when");
-		java.sql.Date actual = new java.sql.Date(jn.getLongValue());
-		long day = 24*3600*1000;  // DateWritable represents days not milliseconds.
+		Assert.assertEquals(epoch/day, jn.getLongValue()/day);
+
+		epoch = 1641578400000L;  // 2022-01-07 18:00 UTC
+        //long zoned = epoch - TimeZone.getDefault().getOffset(epoch);
+        jsd = new java.sql.Date(epoch);  // zoned?
+		stuff = new ArrayList<Object>();
+        addWritable(stuff, jsd);
+        jsw = jserde.serialize(stuff, rowOI);
+		jn = new ObjectMapper().readTree(((Text)jsw).toString());
+		jn = jn.findValue("properties");
+		jn = jn.findValue("when");
+        System.err.println(jn);
 		Assert.assertEquals(epoch/day, jn.getLongValue()/day);
 	}
 
@@ -158,18 +167,20 @@ public class TestGeoJsonSerDe extends JsonSerDeTestingBase {
 		proptab.setProperty(HiveShims.serdeConstants.LIST_COLUMN_TYPES, "date");
 		jserde.initialize(config, proptab);
         StructObjectInspector rowOI = (StructObjectInspector)jserde.getObjectInspector();
+        // Half a day apart to test both a.m. & p.m. whether in East or West
 
-        value.set("{\"properties\":{\"when\":147147147147}}");
+        value.set("{\"properties\":{\"when\":1641535200000}}");  // 2022-01-07 06:00 UTC
 		Object row = jserde.deserialize(value);
 		StructField f0 = rowOI.getStructFieldRef("when");
 		Object fieldData = rowOI.getStructFieldData(row, f0);
 		long day = 24*3600*1000;  // DateWritable represents days not milliseconds.
-        long epochExpected = 147147147147L;
+        long epochExpected = 1641535200000L;  // or likely 00:00 UTC
         Assert.assertEquals(epochExpected/day, epochFromWritable(fieldData)/day);
-        value.set("{\"properties\":{\"when\":142857142857}}");
+
+        value.set("{\"properties\":{\"when\":1641578400000}}");  // 2022-01-07 18:00 UTC
         row = jserde.deserialize(value);
 		fieldData = rowOI.getStructFieldData(row, f0);
-		epochExpected = 142857142857L;
+		epochExpected = 1641578400000L;  // or likely 00:00 UTC
         Assert.assertEquals(epochExpected/day, epochFromWritable(fieldData)/day);
 	}
 


### PR DESCRIPTION
Date-time tests pass with Hive-3.1 profile.
Hive-3.0 and before may exhibit HIVE-12192.
Complete handling of absent/invalid date-time as SQL NULL would be broader scope (separate).
#182 @tpolong