### PR TITLE
Improve MAVEN build Performance - test reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,7 @@
     <surefire.plugin.version>2.12</surefire.plugin.version>
     <source.plugin.version>2.2.1</source.plugin.version>
     <javadoc.plugin.version>2.9.1</javadoc.plugin.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
